### PR TITLE
Allow range of data being returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# SharedMediaStreamer
+# Shared Media Streamer
  Currently a proof of concept for learning video streaming consisting of an API and a website.
  Plans are to have an API that can read a video file and a website that calls on the API to get the video data streamed.
  
-  # C# ASP.Net MVC API
- The API is written in C#. I have introduced the project to SOLID programming principles as well as carefully thought out architecuture.
- It features clean written code that can easily be maintained. The API should have access to the video file and will be reading a set
- amount of bytes and returning it to the consumer.
+## C# ASP.NetCore MVC API
+The API is written in C#. I have introduced the project to SOLID programming principles as well as carefully thought out architecuture.
+It features clean code written with maintainability as priority. The API will read a certain amount of bytes from a media file at a certain offset
+which is defined in the clients request. Once it has finished reading and retrieving the data, it will respond to the consumer.
+
+#### Features:
+###### 3-tiered Architecture:
+- API layer - SDK, Dependency Service Container, Resolvers, Configuration file (app settings json file), Controllers
+- Domain layer - Models, Interfaces, Repositories
+- Media Data Processor layer - Media file reader
+
+###### Code Quality:
+- Good practise
+- S.O.L.I.D design
+- Software Design Principles 

--- a/SharedMediaStreamer.API/Program.cs
+++ b/SharedMediaStreamer.API/Program.cs
@@ -1,11 +1,15 @@
+using SharedMediaStreamer.API.Resolvers;
 using SharedMediaStreamer.Domain;
 using SharedMediaStreamer.Domain.Interfaces;
+using SharedMediaStreamer.Domain.Models.Settings;
 using SharedMediaStreamer.MediaDataProcessor;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddSingleton<IMediaRepository, VideoRepository>();
 builder.Services.AddSingleton<IMediaFileReader, VideoFileReader>();
+
+builder.Services.Configure<MediaSettings>(builder.Configuration.GetSection("MediaSettings"));
 
 // Add services to the container.
 

--- a/SharedMediaStreamer.API/Program.cs
+++ b/SharedMediaStreamer.API/Program.cs
@@ -8,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddSingleton<IMediaRepository, VideoRepository>();
 builder.Services.AddSingleton<IMediaFileReader, VideoFileReader>();
+builder.Services.AddSingleton<IMediaFileReaderResolver, MediaFileReaderResolver>();
 
 builder.Services.Configure<MediaSettings>(builder.Configuration.GetSection("MediaSettings"));
 

--- a/SharedMediaStreamer.API/Resolvers/MediaFileReaderResolver.cs
+++ b/SharedMediaStreamer.API/Resolvers/MediaFileReaderResolver.cs
@@ -1,0 +1,28 @@
+﻿using SharedMediaStreamer.Domain;
+using SharedMediaStreamer.Domain.Interfaces;
+using SharedMediaStreamer.MediaDataProcessor;
+
+namespace SharedMediaStreamer.API.Resolvers
+{
+    public class MediaFileReaderResolver : IMediaFileReaderResolver
+    {
+        private IServiceProvider _serviceProvider;
+        public MediaFileReaderResolver(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+        public IMediaFileReader GetMediaFileReader<T>()
+        {
+            return typeof(IMediaFileReader) switch
+            {
+                var givenType when typeof(T) == typeof(VideoRepository) => GetMediaFileReaderForRepository<T>(typeof(VideoFileReader)),
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        private IMediaFileReader GetMediaFileReaderForRepository<T>(Type mediaFileType)
+        {
+            return _serviceProvider.GetServices<IMediaFileReader>().Single(s => s.GetType() == mediaFileType);
+        }
+    }
+}

--- a/SharedMediaStreamer.API/appsettings.json
+++ b/SharedMediaStreamer.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-}
+  "AllowedHosts": "*",
+  "MediaSettings": {
+    "FilePath": "<FilePath>",
+    "BufferSizeInMB": "<BufferSize>"
+  }
+ }

--- a/SharedMediaStreamer.Domain/Interfaces/IMediaFileReader.cs
+++ b/SharedMediaStreamer.Domain/Interfaces/IMediaFileReader.cs
@@ -1,7 +1,9 @@
-﻿namespace SharedMediaStreamer.Domain.Interfaces
+﻿using SharedMediaStreamer.Domain.Models;
+
+namespace SharedMediaStreamer.Domain.Interfaces
 {
     public interface IMediaFileReader
     {
-        void GetMediaByteContents(byte[] buffer, int offset, int length);
+        MediaDetails GetVideo(int offset, int length);
     }
 }

--- a/SharedMediaStreamer.Domain/Interfaces/IMediaFileReaderResolver.cs
+++ b/SharedMediaStreamer.Domain/Interfaces/IMediaFileReaderResolver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharedMediaStreamer.Domain.Interfaces
+{
+    public interface IMediaFileReaderResolver
+    {
+        IMediaFileReader GetMediaFileReader<T>();
+    }
+}

--- a/SharedMediaStreamer.Domain/Interfaces/IMediaRepository.cs
+++ b/SharedMediaStreamer.Domain/Interfaces/IMediaRepository.cs
@@ -1,7 +1,9 @@
-﻿namespace SharedMediaStreamer.Domain.Interfaces
+﻿using SharedMediaStreamer.Domain.Models;
+
+namespace SharedMediaStreamer.Domain.Interfaces
 {
     public interface IMediaRepository
     {
-        byte[] GetMediaContents(int offset, short bufferSizeInMB = 5);
+        MediaDetails GetMedia(int offset);
     }
 }

--- a/SharedMediaStreamer.Domain/Models/MediaDetails.cs
+++ b/SharedMediaStreamer.Domain/Models/MediaDetails.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace SharedMediaStreamer.Domain.Models
 {
-    public class MediaDetails
+    public abstract class MediaDetails
     {
         public long ContentLength { get; set; }
         public string ContentRange { get; set; }

--- a/SharedMediaStreamer.Domain/Models/MediaDetails.cs
+++ b/SharedMediaStreamer.Domain/Models/MediaDetails.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharedMediaStreamer.Domain.Models
+{
+    public class MediaDetails
+    {
+        public long ContentLength { get; set; }
+        public string ContentRange { get; set; }
+        public string ContentType { get; set; }
+    }
+}

--- a/SharedMediaStreamer.Domain/Models/MediaDetails.cs
+++ b/SharedMediaStreamer.Domain/Models/MediaDetails.cs
@@ -8,8 +8,10 @@ namespace SharedMediaStreamer.Domain.Models
 {
     public abstract class MediaDetails
     {
-        public long ContentLength { get; set; }
-        public string ContentRange { get; set; }
+        public string FileName { get; set; }
+        public long FileLength { get; set; }
         public string ContentType { get; set; }
+        public byte[] Content { get; set; }
+        public long BufferSizeInBytes { get; set; }
     }
 }

--- a/SharedMediaStreamer.Domain/Models/Settings/MediaSettings.cs
+++ b/SharedMediaStreamer.Domain/Models/Settings/MediaSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace SharedMediaStreamer.Domain.Models.Settings
+{
+    public class MediaSettings
+    {
+        public string FilePath { get; set; }
+        public short BufferSizeInMB { get; set; }
+    }
+}

--- a/SharedMediaStreamer.Domain/Models/VideoDetails.cs
+++ b/SharedMediaStreamer.Domain/Models/VideoDetails.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharedMediaStreamer.Domain.Models
+{
+    public class VideoDetails : MediaDetails
+    {
+        public VideoDetails()
+        {
+            this.ContentType = "video/mp4";
+        }
+    }
+}

--- a/SharedMediaStreamer.Domain/SharedMediaStreamer.Domain.csproj
+++ b/SharedMediaStreamer.Domain/SharedMediaStreamer.Domain.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/SharedMediaStreamer.Domain/VideoRepository.cs
+++ b/SharedMediaStreamer.Domain/VideoRepository.cs
@@ -1,23 +1,28 @@
-﻿using SharedMediaStreamer.Domain.Interfaces;
+﻿using Microsoft.Extensions.Options;
+using SharedMediaStreamer.Domain.Interfaces;
+using SharedMediaStreamer.Domain.Models;
+using SharedMediaStreamer.Domain.Models.Settings;
 
 namespace SharedMediaStreamer.Domain
 {
     public class VideoRepository : IMediaRepository
     {
         private IMediaFileReader _mediaFileReader;
-        public VideoRepository(IMediaFileReader mediaFileReader)
+        private short _bufferSizeInMB;
+        public VideoRepository(IMediaFileReaderResolver mediaFileReaderResolver, IOptionsMonitor<MediaSettings> mediaSettings)
         {
-            _mediaFileReader = mediaFileReader;
+            _mediaFileReader = mediaFileReaderResolver.GetMediaFileReader<VideoRepository>();
+            _bufferSizeInMB = mediaSettings.CurrentValue.BufferSizeInMB;
         }
 
-        public byte[] GetMediaContents(int offset, short bufferSizeInMB = 5)
+        public MediaDetails GetMedia(int offset)
         {
-            var bufferSizeInBytes = bufferSizeInMB * 1_000_000;
-            var buffer = new byte[bufferSizeInBytes];
+            return _mediaFileReader.GetVideo(offset, GetBufferSizeInBytes());
+        }
 
-            _mediaFileReader.GetMediaByteContents(buffer, offset, bufferSizeInBytes);
-
-            return buffer;
+        private int GetBufferSizeInBytes()
+        {
+            return _bufferSizeInMB * 1_000_000;
         }
     }
 }

--- a/SharedMediaStreamer.MediaDataProcessor/SharedMediaStreamer.MediaDataProcessor.csproj
+++ b/SharedMediaStreamer.MediaDataProcessor/SharedMediaStreamer.MediaDataProcessor.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SharedMediaStreamer.Domain\SharedMediaStreamer.Domain.csproj" />
   </ItemGroup>
 

--- a/SharedMediaStreamer.MediaDataProcessor/VideoFileReader.cs
+++ b/SharedMediaStreamer.MediaDataProcessor/VideoFileReader.cs
@@ -1,14 +1,32 @@
-﻿using SharedMediaStreamer.Domain.Interfaces;
+﻿using Microsoft.Extensions.Options;
+using SharedMediaStreamer.Domain.Interfaces;
+using SharedMediaStreamer.Domain.Models;
+using SharedMediaStreamer.Domain.Models.Settings;
 
 namespace SharedMediaStreamer.MediaDataProcessor
 {
     public class VideoFileReader : IMediaFileReader
     {
-        public void GetMediaByteContents(byte[] buffer, int offset, int length)
+        private string _pathToTestVideoFile;
+
+        public VideoFileReader(IOptionsMonitor<MediaSettings> mediaSettings)
         {
-            using (FileStream fileStream = File.Open(@"C:\Media\Test.mp4", FileMode.Open))
+            _pathToTestVideoFile = mediaSettings.CurrentValue.FilePath;
+        }
+
+        public MediaDetails GetVideo(int offset, int length)
+        {
+            using (FileStream fileStream = File.Open(_pathToTestVideoFile, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                fileStream.Read(buffer, offset, length);
+                var buffer = new byte[length];
+                fileStream.Seek(offset, SeekOrigin.Begin);
+                fileStream.Read(buffer, 0, length);
+
+                return new VideoDetails() {
+                    FileName = fileStream.Name,
+                    FileLength = fileStream.Length,
+                    Content = buffer
+                };
             }
         }
     }


### PR DESCRIPTION
Returns data to a client when it passes the offset value to read from. The length of the content returned is defined in the app settings which the configuration reads from. The partial content is then returned along with the status headers being set.

- Adds Resolver for dependency injection to inject the relevant media file readers to a repository
- Implements options pattern to allow for the program to be configurable without code changes
- Adds models for settings
- Improve MediaDetails model to return content